### PR TITLE
fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ let () =
   let target = Plot.qt () in
   Plot.(run
          ~target
-         ~plot:(plot2 ~xaxis:"x" ~yaxis:"y" ~title:"sin" [sin])
-         exec)
+         exec
+         (plot2 ~xaxis:"x" ~yaxis:"y" ~title:"sin" [sin]))
 ```
 This produces something like this.
 ![Simple Plot](./assets/plot.png)


### PR DESCRIPTION
current signature of run is: `?path ?silent ~target action plot` ...example uses `~plot` which gives error